### PR TITLE
Progress GET/POST backed by redis

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -286,3 +286,10 @@ CHANNEL_LAYERS = {
         "ROUTING": "chaneleria.routing.channel_routing",
     },
 }
+
+
+# Settings for storing progress in redis  (used for sushichef MMVP)
+MMVP_REDIS_HOST = 'localhost'
+MMVP_REDIS_PORT = 6379
+MMVP_REDIS_DB = 0
+

--- a/runs/serializers.py
+++ b/runs/serializers.py
@@ -82,7 +82,7 @@ class ChannelRunLogMessageCreateSerializer(serializers.Serializer):
 
 
 
-class ChannelRunProgressReceiveSerializer(serializers.Serializer):
+class ChannelRunProgressSerializer(serializers.Serializer):
     """
     Run progress messages are of the form:
     {

--- a/runs/urls.py
+++ b/runs/urls.py
@@ -5,7 +5,7 @@ from .api import ContentChannelListCreate, ContentChannelDetail, RunsForContentC
 from .api import ContentChannelRunListCreate, ContentChannelRunDetail
 from .api import ChannelRunStageListCreate
 from .api import ChannelRunLogMessageCreate
-from .api import ChannelRunProgressViews
+from .api import ChannelRunProgressEndpoints
 
 urlpatterns = [
     url(regex=r'channels/$',
@@ -37,7 +37,7 @@ urlpatterns = [
         name='create_run_log_message'),
     #
     url(regex=r'channelruns/(?P<run_id>[0-9A-Fa-f-]+)/progress/$',
-        view=ChannelRunProgressViews.as_view(),
+        view=ChannelRunProgressEndpoints.as_view(),
         name='run_progress'),
 ]
 


### PR DESCRIPTION
Example usage:

GET/POST to /api/channelruns/f2c0906a77ce4651b5aedaa2b25bb3d9/progress/

using the following wire format:

```
  {
    "run_id": "f2c0906a77ce4651b5aedaa2b25bb3d9",
    "stage": "Stage.SOMESTAGENAME2",
    "progress": 0.3
  }
```